### PR TITLE
修复 Vivaldi 侧边栏无法识别网页上下文的问题

### DIFF
--- a/background/handlers/session/prompt_handler.js
+++ b/background/handlers/session/prompt_handler.js
@@ -107,14 +107,15 @@ export class PromptHandler {
 
                 // AUTO-LOCK: If browser control enabled and no tab locked, lock to active tab
                 if (request.enableBrowserControl && this.controlManager) {
-                    this.controlManager.setOwnerSidePanelTabId(request.sidePanelTabId || null);
+                    const targetSidePanelTabId = request.sidePanelTabId || null;
+                    this.controlManager.setOwnerSidePanelTabId(targetSidePanelTabId);
                     this.controlManager.setControlTaskTitle(
                         getBrowserControlTaskTitle(request.text)
                     );
                     const currentLock = this.controlManager.getTargetTabId();
                     if (!currentLock) {
                         await this.controlManager.enableControl({
-                            createDefaultTab: request.hostIsTab === true,
+                            createDefaultTab: request.hostIsTab === true && !targetSidePanelTabId,
                         });
                         const lockedTabId = this.controlManager.getTargetTabId();
                         if (lockedTabId) {
@@ -124,7 +125,7 @@ export class PromptHandler {
                                 chrome.runtime
                                     .sendMessage({
                                         action: 'TAB_LOCKED',
-                                        tabId: request.sidePanelTabId || null,
+                                        tabId: targetSidePanelTabId,
                                         tab: toControlTabSummary(tab),
                                     })
                                     .catch(() => {});

--- a/background/handlers/session/prompt_handler.test.js
+++ b/background/handlers/session/prompt_handler.test.js
@@ -171,7 +171,7 @@ describe('PromptHandler concurrency', () => {
         expect(controlManager.enableControl).toHaveBeenCalledWith({ createDefaultTab: false });
     });
 
-    it('asks browser control to create a default tab for standalone chat prompts', async () => {
+    it('does not create a default Google tab for host-tab prompts with webpage context', async () => {
         globalThis.chrome = {
             runtime: {
                 sendMessage: vi.fn(() => Promise.resolve()),
@@ -216,6 +216,59 @@ describe('PromptHandler concurrency', () => {
                 enableBrowserControl: true,
                 hostIsTab: true,
                 sidePanelTabId: 123,
+            },
+            sendResponse
+        );
+
+        await vi.waitFor(() =>
+            expect(controlManager.enableControl).toHaveBeenCalledWith({ createDefaultTab: false })
+        );
+    });
+
+    it('creates a default Google tab for true standalone chat prompts', async () => {
+        globalThis.chrome = {
+            runtime: {
+                sendMessage: vi.fn(() => Promise.resolve()),
+            },
+            tabs: {
+                get: vi.fn(() =>
+                    Promise.resolve({
+                        id: 700,
+                        title: 'Google Search',
+                        url: 'https://www.google.com/search?q=',
+                    })
+                ),
+                query: vi.fn(() => Promise.resolve([])),
+            },
+        };
+        const sessionManager = {
+            handleSendPrompt: vi.fn(() =>
+                Promise.resolve({
+                    action: 'GEMINI_REPLY',
+                    sessionId: 'session-1',
+                    status: 'success',
+                    text: 'done',
+                })
+            ),
+        };
+        const controlManager = {
+            setOwnerSidePanelTabId: vi.fn(),
+            setControlTaskTitle: vi.fn(),
+            enableControl: vi.fn(() => Promise.resolve(true)),
+            getTargetTabId: vi.fn().mockReturnValueOnce(null).mockReturnValue(700),
+            getSnapshot: vi.fn(() => Promise.resolve('snapshot')),
+        };
+        const handler = new PromptHandler(sessionManager, controlManager, null);
+        const sendResponse = vi.fn();
+
+        handler.handle(
+            {
+                action: 'SEND_PROMPT',
+                text: 'Open a browser',
+                model: 'gemini-test',
+                sessionId: 'session-1',
+                enableBrowserControl: true,
+                hostIsTab: true,
             },
             sendResponse
         );

--- a/background/handlers/ui.test.js
+++ b/background/handlers/ui.test.js
@@ -45,7 +45,7 @@ describe('UIMessageHandler browser control tab ownership', () => {
         expect(sendResponse).toHaveBeenCalledWith({ status: 'processed' });
     });
 
-    it('asks browser control to create a default tab for standalone chat pages', () => {
+    it('does not create a default Google tab for host-tab chat pages with webpage context', () => {
         const sendResponse = vi.fn();
 
         const handled = handler.handle(
@@ -61,6 +61,25 @@ describe('UIMessageHandler browser control tab ownership', () => {
 
         expect(handled).toBe(true);
         expect(controlManager.setOwnerSidePanelTabId).toHaveBeenCalledWith(123);
+        expect(controlManager.enableControl).toHaveBeenCalledWith({ createDefaultTab: false });
+        expect(sendResponse).toHaveBeenCalledWith({ status: 'processed' });
+    });
+
+    it('creates a default Google tab for true standalone chat pages', () => {
+        const sendResponse = vi.fn();
+
+        const handled = handler.handle(
+            {
+                action: 'TOGGLE_BROWSER_CONTROL',
+                enabled: true,
+                hostIsTab: true,
+            },
+            {},
+            sendResponse
+        );
+
+        expect(handled).toBe(true);
+        expect(controlManager.setOwnerSidePanelTabId).toHaveBeenCalledWith(null);
         expect(controlManager.enableControl).toHaveBeenCalledWith({ createDefaultTab: true });
         expect(sendResponse).toHaveBeenCalledWith({ status: 'processed' });
     });

--- a/background/handlers/ui_browser_control.js
+++ b/background/handlers/ui_browser_control.js
@@ -1,11 +1,10 @@
 export function handleToggleBrowserControl(context, request, sender, sendResponse) {
     if (context.controlManager) {
-        context.controlManager.setOwnerSidePanelTabId?.(
-            context.getTargetSidePanelTabId(request, sender)
-        );
+        const targetSidePanelTabId = context.getTargetSidePanelTabId(request, sender);
+        context.controlManager.setOwnerSidePanelTabId?.(targetSidePanelTabId);
         if (request.enabled) {
             context.controlManager.enableControl({
-                createDefaultTab: request.hostIsTab === true,
+                createDefaultTab: request.hostIsTab === true && !targetSidePanelTabId,
             });
         } else {
             context.controlManager.disableControl();

--- a/css/header.css
+++ b/css/header.css
@@ -20,7 +20,7 @@ body.layout-wide #history-toggle {
     display: none;
 }
 
-body.host-tab #open-full-page-btn {
+body.host-tab:not(.has-page-context) #open-full-page-btn {
     display: none;
 }
 

--- a/css/input.css
+++ b/css/input.css
@@ -275,7 +275,7 @@ body.layout-wide .input-wrapper {
     color: var(--primary);
 }
 
-body.host-tab .tool-btn.context-aware {
+body:not(.has-page-context) .tool-btn.context-aware {
     display: none;
 }
 

--- a/css/settings_layout.test.js
+++ b/css/settings_layout.test.js
@@ -94,15 +94,18 @@ describe('settings layout styles', () => {
         expect(formsCss).toMatch(/\.settings-input\.settings-select\s*{[^}]*width:\s*100%/s);
     });
 
-    it('hides webpage-context tools only in standalone chat tabs', async () => {
+    it('hides webpage-context controls only when no page context is available', async () => {
         const inputCss = await readCss('./input.css');
         const headerCss = await readCss('./header.css');
 
+        expect(inputCss).not.toMatch(/body\.host-tab\s+\.tool-btn\.context-aware/s);
         expect(inputCss).toMatch(
-            /body\.host-tab\s+\.tool-btn\.context-aware\s*{[^}]*display:\s*none/s
+            /body:not\(\.has-page-context\)\s+\.tool-btn\.context-aware\s*{[^}]*display:\s*none/s
         );
         expect(inputCss).not.toMatch(/body\.layout-wide\s+\.tool-btn\.context-aware/s);
-        expect(headerCss).toMatch(/body\.host-tab\s+#open-full-page-btn\s*{[^}]*display:\s*none/s);
+        expect(headerCss).toMatch(
+            /body\.host-tab:not\(\.has-page-context\)\s+#open-full-page-btn\s*{[^}]*display:\s*none/s
+        );
         expect(headerCss).not.toMatch(
             /@media\s*\(max-width:\s*600px\)[\s\S]*#open-full-page-btn\s*{[^}]*display:\s*none/s
         );

--- a/sandbox/controllers/app_controller.js
+++ b/sandbox/controllers/app_controller.js
@@ -305,6 +305,9 @@ export class AppController {
             this.currentTabUrl = payload?.url || '';
             this.currentTabTitle = payload?.title || '';
             this.boundSessionId = payload?.sessionId || null;
+            this.ui.setPageContextAvailable?.(
+                Number.isInteger(this.currentTabId) && this.currentTabId > 0
+            );
             if (this.sessionsRestored && this.sidePanelScope === DEFAULT_SIDE_PANEL_SCOPE) {
                 this.restoreRememberedTabSession();
             }

--- a/sandbox/controllers/app_controller.test.js
+++ b/sandbox/controllers/app_controller.test.js
@@ -51,6 +51,7 @@ function createUi() {
             updateSidePanelScope: vi.fn(),
         },
         setBrowserControlVisible: vi.fn(),
+        setPageContextAvailable: vi.fn(),
         setLoading: vi.fn(),
         updateBrowserControlState: vi.fn(),
         updateWebThinkingToggle: vi.fn(),
@@ -176,6 +177,26 @@ describe('AppController session restore behavior', () => {
 
         expect(app.currentTabId).toBe(123);
         expect(sessionManager.currentSessionId).toBe('real');
+    });
+
+    it('updates page-context availability from restored tab context', async () => {
+        const { app, ui } = createAppHarness();
+
+        await app.handleIncomingMessage({
+            data: {
+                action: 'RESTORE_SIDE_PANEL_TAB_CONTEXT',
+                payload: { tabId: 123 },
+            },
+        });
+        expect(ui.setPageContextAvailable).toHaveBeenCalledWith(true);
+
+        await app.handleIncomingMessage({
+            data: {
+                action: 'RESTORE_SIDE_PANEL_TAB_CONTEXT',
+                payload: { tabId: null },
+            },
+        });
+        expect(ui.setPageContextAvailable).toHaveBeenCalledWith(false);
     });
 
     it('restores saved groups and rerenders history after sessions are loaded', async () => {

--- a/sandbox/ui/ui_controller.js
+++ b/sandbox/ui/ui_controller.js
@@ -65,6 +65,10 @@ export class UIController {
         document.body.classList.toggle('host-tab', context.isTab === true);
     }
 
+    setPageContextAvailable(isAvailable) {
+        document.body.classList.toggle('has-page-context', isAvailable === true);
+    }
+
     scheduleLayoutCheck() {
         if (this.layoutResizeFrame !== null) return;
 

--- a/sandbox/ui/ui_controller.test.js
+++ b/sandbox/ui/ui_controller.test.js
@@ -29,4 +29,14 @@ describe('UIController host context', () => {
         controller.setHostContext({ isTab: false });
         expect(document.body.classList.contains('host-tab')).toBe(false);
     });
+
+    it('marks whether the chat has a real webpage context', () => {
+        const controller = Object.create(UIController.prototype);
+
+        controller.setPageContextAvailable(true);
+        expect(document.body.classList.contains('has-page-context')).toBe(true);
+
+        controller.setPageContextAvailable(false);
+        expect(document.body.classList.contains('has-page-context')).toBe(false);
+    });
 });

--- a/sidepanel/core/bridge.js
+++ b/sidepanel/core/bridge.js
@@ -48,11 +48,17 @@ const FORWARDED_RESPONSE_ACTIONS = new Set([
     'GET_PROVIDER_MODELS',
 ]);
 
-const HOST_ROUTED_ACTIONS = new Set(['GET_OPEN_TABS', 'SWITCH_TAB', 'TOGGLE_BROWSER_CONTROL']);
+const HOST_ROUTED_ACTIONS = new Set(['GET_OPEN_TABS', 'SWITCH_TAB']);
 
 function shouldRouteToHostTab(payload) {
     if (!payload || typeof payload !== 'object') return false;
     if (HOST_ROUTED_ACTIONS.has(payload.action)) return true;
+    return payload.action === 'SEND_PROMPT' && payload.enableBrowserControl === true;
+}
+
+function shouldRequirePageContextRoute(payload) {
+    if (!payload || typeof payload !== 'object') return false;
+    if (payload.action === 'TOGGLE_BROWSER_CONTROL') return true;
     return payload.action === 'SEND_PROMPT' && payload.enableBrowserControl === true;
 }
 
@@ -78,7 +84,7 @@ export class MessageBridge {
     }
 
     openFullPage() {
-        const url = chrome.runtime.getURL('sidepanel/index.html');
+        const url = chrome.runtime.getURL('sidepanel/index.html?standalone=1');
         chrome.tabs.create({ url });
     }
 
@@ -299,9 +305,11 @@ export class MessageBridge {
             return payload;
         }
 
-        const tabId = shouldRouteToHostTab(payload)
-            ? this._getMessageTargetTabId()
-            : this.state.getCurrentTabId();
+        const tabId = shouldRequirePageContextRoute(payload)
+            ? this.state.getCurrentTabId()
+            : shouldRouteToHostTab(payload)
+              ? this._getMessageTargetTabId()
+              : this.state.getCurrentTabId();
         if (!Number.isInteger(tabId) || tabId <= 0) {
             return payload;
         }

--- a/sidepanel/core/bridge.test.js
+++ b/sidepanel/core/bridge.test.js
@@ -105,6 +105,24 @@ describe('MessageBridge model persistence', () => {
         expect(state.save).not.toHaveBeenCalledWith('geminiModel', 'deepseek-v4-pro');
     });
 
+    it('marks full-page chat launches as standalone tabs', () => {
+        const frame = createFrame();
+        const state = createState();
+        const bridge = new MessageBridge(frame, state);
+        chrome.runtime.getURL = vi.fn((path) => `chrome-extension://id/${path}`);
+
+        bridge.handleWindowMessage({
+            source: frame.getWindow(),
+            data: {
+                action: 'OPEN_FULL_PAGE',
+            },
+        });
+
+        expect(chrome.tabs.create).toHaveBeenCalledWith({
+            url: 'chrome-extension://id/sidepanel/index.html?standalone=1',
+        });
+    });
+
     it('merges side panel session bindings with existing session storage', () => {
         const frame = createFrame();
         const state = createState();
@@ -211,7 +229,7 @@ describe('MessageBridge model persistence', () => {
         });
     });
 
-    it('routes browser control toggles through the standalone host tab id', () => {
+    it('does not route browser control toggles through a standalone host tab without webpage context', () => {
         const frame = createFrame();
         const state = createState();
         state.getCurrentTabId.mockReturnValue(null);
@@ -228,11 +246,10 @@ describe('MessageBridge model persistence', () => {
             action: 'TOGGLE_BROWSER_CONTROL',
             enabled: true,
             hostIsTab: true,
-            sidePanelTabId: 777,
         });
     });
 
-    it('routes browser-control prompts through the standalone host tab id', () => {
+    it('routes browser-control prompts through the current webpage tab id', () => {
         const frame = createFrame();
         const state = createState();
         state.getCurrentTabId.mockReturnValue(33);
@@ -251,7 +268,7 @@ describe('MessageBridge model persistence', () => {
             text: 'Open Google',
             enableBrowserControl: true,
             hostIsTab: true,
-            sidePanelTabId: 777,
+            sidePanelTabId: 33,
         });
     });
 

--- a/sidepanel/core/state.js
+++ b/sidepanel/core/state.js
@@ -14,6 +14,15 @@ export function getOwnerTabIdFromLocation(locationLike = window.location) {
     }
 }
 
+export function isStandalonePageFromLocation(locationLike = window.location) {
+    try {
+        const url = new URL(locationLike.href);
+        return url.searchParams.get('standalone') === '1';
+    } catch {
+        return false;
+    }
+}
+
 export function isExtensionHostPageTab(tab) {
     if (!tab || typeof tab.url !== 'string') return false;
 
@@ -32,6 +41,21 @@ export function isExtensionHostPageTab(tab) {
     }
 }
 
+export function getContextTabFromTabs(tabs, fallback = null) {
+    if (!Array.isArray(tabs)) return fallback;
+
+    const pageTabs = tabs.filter((tab) => tab && !isExtensionHostPageTab(tab));
+    const activeTab = pageTabs.find((tab) => tab.active === true);
+    if (activeTab) return activeTab;
+
+    return (
+        pageTabs
+            .slice()
+            .sort((left, right) => (right.lastAccessed || 0) - (left.lastAccessed || 0))[0] ||
+        fallback
+    );
+}
+
 function cacheSidebarExpandedPreference(isExpanded) {
     localStorage.setItem('geminiSidebarExpanded', isExpanded === false ? 'false' : 'true');
 }
@@ -46,8 +70,9 @@ export class StateManager {
         this.localStorageData = null;
         this.sessionStorageData = null;
         this.ownerTabId = getOwnerTabIdFromLocation();
+        this.isStandalonePage = isStandalonePageFromLocation();
         this.hostTabId = null;
-        this.currentTabId = this.ownerTabId ?? undefined;
+        this.currentTabId = this.ownerTabId ?? (this.isStandalonePage ? null : undefined);
         this.uiIsReady = false;
         this.hasInitialized = false;
     }
@@ -105,16 +130,16 @@ export class StateManager {
             });
         }
 
-        if (this.hasFixedTabContext()) {
+        if (this.hasFixedTabContext() || this.isStandalonePage) {
             this.trySendInitData();
         } else {
-            chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+            chrome.tabs.query({ currentWindow: true }, (tabs) => {
                 const errorMessage = getRuntimeLastErrorMessage();
                 if (errorMessage) {
                     console.warn('Failed to resolve active side panel tab:', errorMessage);
                     this.currentTabId = null;
                 } else {
-                    const tab = tabs && tabs[0] ? tabs[0] : null;
+                    const tab = getContextTabFromTabs(tabs);
                     this.currentTabId = this.getContextTabId(tab, null);
                 }
                 this.trySendInitData();
@@ -138,6 +163,7 @@ export class StateManager {
 
         chrome.tabs.onActivated.addListener(({ tabId }) => {
             if (this.hasFixedTabContext()) return;
+            if (this.isStandalonePage) return;
 
             this.updateCurrentTabFromActivatedTab(tabId);
         });
@@ -159,13 +185,14 @@ export class StateManager {
             }
 
             if (this.hasFixedTabContext()) return;
+            if (this.isStandalonePage) return;
 
             if (this.currentTabId === tabId) {
-                chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+                chrome.tabs.query({ currentWindow: true }, (tabs) => {
                     if (getRuntimeLastErrorMessage()) {
                         this.currentTabId = null;
                     } else {
-                        const tab = tabs && tabs[0] ? tabs[0] : null;
+                        const tab = getContextTabFromTabs(tabs);
                         this.currentTabId = this.getContextTabId(tab, null);
                     }
                     this.postCurrentTabContext();
@@ -301,7 +328,7 @@ export class StateManager {
     }
 
     getMessageTargetTabId() {
-        return this.hostTabId || this.currentTabId;
+        return this.currentTabId || this.hostTabId;
     }
 
     getContextTabId(tab, fallback = null) {

--- a/sidepanel/core/state.test.js
+++ b/sidepanel/core/state.test.js
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { StateManager, getOwnerTabIdFromLocation, isExtensionHostPageTab } from './state.js';
+import {
+    StateManager,
+    getContextTabFromTabs,
+    getOwnerTabIdFromLocation,
+    isStandalonePageFromLocation,
+    isExtensionHostPageTab,
+} from './state.js';
 
 function createFrame() {
     return {
@@ -91,6 +97,20 @@ describe('StateManager tab ownership', () => {
         expect(getOwnerTabIdFromLocation({ href: 'not a url' })).toBeNull();
     });
 
+    it('recognizes full-page chat launches as standalone pages', () => {
+        expect(
+            isStandalonePageFromLocation({
+                href: 'chrome-extension://id/sidepanel/index.html?standalone=1',
+            })
+        ).toBe(true);
+        expect(
+            isStandalonePageFromLocation({
+                href: 'chrome-extension://id/sidepanel/index.html',
+            })
+        ).toBe(false);
+        expect(isStandalonePageFromLocation({ href: 'not a url' })).toBe(false);
+    });
+
     it('recognizes extension-hosted chat pages as non-webpage tab contexts', () => {
         expect(
             isExtensionHostPageTab({
@@ -132,7 +152,7 @@ describe('StateManager tab ownership', () => {
         listeners.activated({ tabId: 44 });
 
         expect(chrome.tabs.query).toHaveBeenCalledWith(
-            { active: true, currentWindow: true },
+            { currentWindow: true },
             expect.any(Function)
         );
         expect(manager.getCurrentTabId()).toBe(44);
@@ -149,6 +169,33 @@ describe('StateManager tab ownership', () => {
         manager.init();
 
         expect(manager.getCurrentTabId()).toBeNull();
+    });
+
+    it('does not bind a marked standalone full-page chat to a recent webpage tab', () => {
+        window.history.replaceState(null, '', '/sidepanel/index.html?standalone=1');
+        const listeners = setupChrome({ id: 33, active: true, url: 'https://active.test/' });
+        const manager = new StateManager(createFrame());
+
+        manager.init();
+        listeners.activated({ tabId: 33 });
+
+        expect(chrome.tabs.query).not.toHaveBeenCalled();
+        expect(manager.getCurrentTabId()).toBeNull();
+    });
+
+    it('falls back to the most recently accessed webpage when the active tab is an extension page', () => {
+        const contextTab = getContextTabFromTabs([
+            {
+                id: 44,
+                active: true,
+                lastAccessed: 300,
+                url: 'chrome-extension://id/sidepanel/index.html',
+            },
+            { id: 45, active: false, lastAccessed: 200, url: 'https://older.test/' },
+            { id: 46, active: false, lastAccessed: 400, url: 'https://recent.test/' },
+        ]);
+
+        expect(contextTab.id).toBe(46);
     });
 
     it('uses the standalone host tab id for message routing without page context', () => {
@@ -168,6 +215,17 @@ describe('StateManager tab ownership', () => {
         manager.setHostTabId(null);
 
         expect(manager.getMessageTargetTabId()).toBeNull();
+    });
+
+    it('prefers webpage context over the standalone host tab for message routing', () => {
+        setupChrome(33);
+        const manager = new StateManager(createFrame());
+
+        manager.init();
+        manager.setHostTabId(777);
+
+        expect(manager.getCurrentTabId()).toBe(33);
+        expect(manager.getMessageTargetTabId()).toBe(33);
     });
 
     it('keeps the previous webpage context when standalone chat becomes active', () => {


### PR DESCRIPTION
## 背景

在 Vivaldi 中使用侧边栏时，扩展页面会表现得像运行在一个扩展宿主 tab 中。现有逻辑把 `host-tab` / `hostIsTab` 等同于“没有真实网页上下文”，导致 Vivaldi 侧边栏被误判为独立扩展页。

![](https://img.723123.xyz/file/1780579256426_PixPin_2026-06-04_21-20-22.png)

表现包括：

- 网页上下文、引用、OCR、截图翻译、截图等按钮不显示
- “在新标签页打开”按钮不显示
- 浏览器控制会自动打开默认 Google 页面
- 无法读取当前浏览器已有页面

Chrome / Edge 没有暴露这个问题，是因为它们的 side panel 不会以同样方式表现为扩展宿主 tab。

## 修复思路

这次修复不做 Vivaldi UA 特判，而是拆分两个概念：

- `host-tab`：表示 UI 运行在扩展宿主页 / tab 形态中
- `has-page-context`：表示当前 UI 是否真的绑定了网页 tab

这样可以保留原本独立扩展页的设计，同时让 Vivaldi 侧边栏正确绑定真实网页上下文。

## 主要改动

- side panel 初始化时会从当前窗口 tab 中跳过扩展自身页面，优先选择活动网页，否则选择最近访问的网页
- 消息路由优先使用真实网页 `currentTabId`，避免上下文、截图、OCR 等请求打到扩展页
- 新增 `has-page-context` UI 状态，CSS 不再仅凭 `host-tab` 隐藏网页上下文工具
- “新标签页打开”的 full-page chat 使用 `standalone=1` 标记，避免独立页被最近访问网页误绑定
- 浏览器控制只在真正独立扩展页且没有网页上下文时才创建默认 Google 控制页
- prompt auto-lock 使用同样判断，避免 Vivaldi 侧边栏误开默认页

## 验证

已本地验证：

- Vivaldi 侧边栏：网页上下文相关按钮恢复显示，浏览器控制不再固定打开 Google
- Chrome / Edge 侧边栏：行为保持正常
- 独立扩展页：仍保持原设计，不显示网页上下文工具

自动化检查：

- targeted tests
- Prettier check
- TypeScript `--noEmit`
- `lint:unused`
- `git diff --check`
- extension package build